### PR TITLE
Add more chord types

### DIFF
--- a/acordes/chord.py
+++ b/acordes/chord.py
@@ -15,7 +15,31 @@ suffix_meanings = {
     "m7":     (P1, m3, P5, m7),
     "mM7":    (P1, m3, P5, M7),
     "7":      (P1, M3, P5, m7),
-    "M7":     (P1, M3, P5, M7)
+    "M7":     (P1, M3, P5, M7),
+    "aug":    (P1, M3, m6),
+    "dim":    (P1, m3, A4),
+    "dim7":   (P1, m3, A4, M6),
+    "m7b5":   (P1, m3, A4, m7),
+    "7b5":    (P1, M3, A4, m7),
+    "aug7":   (P1, M3, m6, m7),
+    "augM7":  (P1, M3, m6, M7),
+    "sus2":   (P1, M2, P5),
+    "sus4":   (P1, P4, P5),
+    "9":      (P1, M3, P5, m7, M2),
+    "m9":     (P1, m3, P5, m7, M2),
+    "M9":     (P1, M3, P5, M7, M2),
+    "mM9":    (P1, m3, P5, M7, M2),
+    "7b9":    (P1, M3, P5, m7, m2),
+    "aug9":   (P1, M3, m6, m7, M2),
+    "augM9":  (P1, M3, m6, M7, M2),
+    "dim9":   (P1, m3, A4, M6, M2),
+    "dimb9":  (P1, m3, A4, M6, m2),
+    "m9b5":   (P1, m3, A4, m7, M2),
+    "mb9b5":  (P1, m3, A4, m7, m2),
+    "2":      (P1, M3, P5, M2),      # aka add9
+    "m2":     (P1, m3, P5, M2),      # aka madd9
+    "6":      (P1, M3, P5, M6),      # aka add13
+    "m6":     (P1, m3, P5, M2)       # aka madd13
 }
 
 


### PR DESCRIPTION
Look at <https://en.wikipedia.org/wiki/Chord_notation> for more and for tips about naming and note skipping for chords like 11. I didn’t add 11 and 13 though because it seems pretty unnecessary right now, and also because with current architecture it would make just a gigantic enumeration. You’ll probably still want me to omit more.